### PR TITLE
[fix] デシリアライズで無効な値が渡された場合にErrを返すように修正

### DIFF
--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -17,7 +17,7 @@ impl<'de> Visitor<'de> for GuildIdVisitor {
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
         where
             E: serde::de::Error, {
-        Ok(WrappedGuildId(v.parse().unwrap()))
+        v.parse().map(|e| WrappedGuildId(e)).map_err(serde::de::Error::custom)
     }
 }
 
@@ -52,7 +52,7 @@ impl<'de> Visitor<'de> for RoleIdVisitor {
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
         where
             E: serde::de::Error, {
-        Ok(WrappedRoleId(v.parse().unwrap()))
+        v.parse().map(|e| WrappedRoleId(e)).map_err(serde::de::Error::custom)
     }
 }
 

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -3,7 +3,7 @@ use serde::{Serialize, Deserialize, de::Visitor};
 
 //GuildIdのDeserialize実装はU64Visitorで文字列から直接デシリアライズできないため、VisitorでDeserializeを独自実装する。
 #[derive(Hash, PartialEq, Eq, Debug, Serialize)]
-pub struct WrappedGuildId (u64);
+pub struct WrappedGuildId (pub u64);
 
 struct GuildIdVisitor;
 
@@ -38,7 +38,7 @@ impl From<GuildId> for WrappedGuildId {
 
 //GuildIdと同じく、RoleIdのDeserialize実装はU64Visitorで文字列から直接デシリアライズできないため、VisitorでDeserializeを独自実装する。
 #[derive(Hash, PartialEq, Eq, Debug, Serialize)]
-pub struct WrappedRoleId (u64);
+pub struct WrappedRoleId (pub u64);
 
 struct RoleIdVisitor;
 
@@ -72,7 +72,7 @@ impl From<RoleId> for WrappedRoleId {
 
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct WrappedPermissions (u64);
+pub struct WrappedPermissions (pub u64);
 
 impl From<Permissions> for WrappedPermissions {
     fn from(value: Permissions) -> Self {


### PR DESCRIPTION
`WrappedGuildId`と`WrappedRoleId`のデシリアライズで`&str`から`u64`への パースに失敗した場合にエラーメッセージを`Err`に包んで返すように修正した。